### PR TITLE
feat: display asset edition number and authority in explorer details

### DIFF
--- a/components/Explorer/ExplorerPluginDetails.tsx
+++ b/components/Explorer/ExplorerPluginDetails.tsx
@@ -19,6 +19,12 @@ export function ExplorerPluginDetails({ plugins, type }: { plugins: PluginsList,
   return (
     <Stack>
       <Text fz="md" tt="uppercase" fw={700} c="dimmed">{type === 'asset' ? 'Asset' : 'Collection'} Plugin Details</Text>
+      {plugins.edition && (
+        <>
+          <ExplorerStat label="Edition Number" value={plugins.edition.number.toString()} />
+          <AuthorityStat authority={plugins.edition.authority} name="Edition" />
+        </>
+      )}
       <ExplorerStat label="Frozen" value={(plugins.freezeDelegate?.frozen || plugins.permanentFreezeDelegate?.frozen) ? 'Yes' : 'No'} />
       {plugins.freezeDelegate && <AuthorityStat authority={plugins.freezeDelegate.authority} name="Freeze" />}
       {plugins.burnDelegate && <AuthorityStat authority={plugins.burnDelegate.authority} name="Burn" />}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@mantine/nprogress": "^7.3.2",
     "@mantine/tiptap": "^7.3.2",
     "@metaplex-foundation/digital-asset-standard-api": "^1.0.0",
-    "@metaplex-foundation/mpl-core": "^0.4.3",
+    "@metaplex-foundation/mpl-core": "^0.4.6",
     "@metaplex-foundation/mpl-toolbox": "^0.9.1",
     "@metaplex-foundation/umi": "^0.8.10",
     "@metaplex-foundation/umi-bundle-defaults": "^0.8.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,13 +2708,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metaplex-foundation/mpl-core@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@metaplex-foundation/mpl-core@npm:0.4.3"
+"@metaplex-foundation/mpl-core@npm:^0.4.6":
+  version: 0.4.6
+  resolution: "@metaplex-foundation/mpl-core@npm:0.4.6"
   peerDependencies:
     "@metaplex-foundation/umi": ">=0.8.2 < 1"
     "@noble/hashes": ^1.3.1
-  checksum: 15b983d2b9797bd8a44f2770891c5d8fff6dbac16c92c851414b804184007bfb68b9fdd0103786fc47bc34d29f9405d8da1a6d8d6f4f49ecb3f485a83e17bcd1
+  checksum: 15c559ad1568dd6410904cff780e0e3790edbc7e8015f65e1b5982cb9970cd6f5b12a4d18e227272f0a6d98eeba06308c93ac9a3653e9568a556fcd38baa7b78
   languageName: node
   linkType: hard
 
@@ -15059,7 +15059,7 @@ __metadata:
     "@mantine/nprogress": "npm:^7.3.2"
     "@mantine/tiptap": "npm:^7.3.2"
     "@metaplex-foundation/digital-asset-standard-api": "npm:^1.0.0"
-    "@metaplex-foundation/mpl-core": "npm:^0.4.3"
+    "@metaplex-foundation/mpl-core": "npm:^0.4.6"
     "@metaplex-foundation/mpl-toolbox": "npm:^0.9.1"
     "@metaplex-foundation/umi": "npm:^0.8.10"
     "@metaplex-foundation/umi-bundle-defaults": "npm:^0.8.10"


### PR DESCRIPTION
![CleanShot 2024-05-06 at 14 53 56@2x](https://github.com/metaplex-foundation/mpl-core-ui/assets/18336973/70cbdcb2-8739-435c-ac13-36f11310d6b3)
