### PR TITLE
fix NFT creation with permanentBurn Plugin

### DIFF
--- a/components/Create/Create.tsx
+++ b/components/Create/Create.tsx
@@ -87,7 +87,7 @@ const mapPlugins = (plugins: AuthorityManagedPluginValues): CreateArgsPlugin[] =
       type: 'PermanentBurnDelegate',
       authority: {
         type: 'Address',
-        address: publicKey(plugins.update.authority),
+        address: publicKey(plugins.permanentBurn.authority),
       },
     });
   }


### PR DESCRIPTION
This uses the correct field for the authority of the permanent burn delegate plugin.
Otherwise the pubkey from the update delegate is used / the following error thrown when the update delegate is not used:
<img width="1016" height="77" alt="grafik" src="https://github.com/user-attachments/assets/11c39879-8111-4182-8b50-a7888cbb8d01" />
