### PR TITLE
refactor: centralize environment config into single source of truth

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import { IconChevronDown } from '@tabler/icons-react';
 import { WalletMultiButton } from '@solana/wallet-adapter-react-ui';
 
 import classes from './Header.module.css';
-import { Env } from '@/providers/useEnv';
+import { Env, EnvOption, getEnvOptions } from '@/providers/useEnv';
 import RetainQueryLink from '../RetainQueryLink';
 
 const HeaderLink = ({ label, link, disabled }: { label: string, link: string, disabled?: boolean }) => {
@@ -16,6 +16,7 @@ const HeaderLink = ({ label, link, disabled }: { label: string, link: string, di
 };
 
 export function Header({ env, setEnv }: { env: string; setEnv: (env: Env) => void }) {
+  const envOptions = getEnvOptions();
   return (
     <Container size="xl" pt={12}>
       <div className={classes.inner}>
@@ -42,14 +43,9 @@ export function Header({ env, setEnv }: { env: string; setEnv: (env: Env) => voi
               </a>
             </Menu.Target>
             <Menu.Dropdown>
-              <Menu.Item onClick={() => setEnv('mainnet')}>Solana Mainnet</Menu.Item>
-              <Menu.Item onClick={() => setEnv('devnet')}>Solana Devnet</Menu.Item>
-              <Menu.Item onClick={() => setEnv('eclipse-mainnet')}>Eclipse Mainnet</Menu.Item>
-              <Menu.Item onClick={() => setEnv('eclipse-devnet')}>Eclipse Devnet</Menu.Item>
-              <Menu.Item onClick={() => setEnv('eclipse-testnet')}>Eclipse Testnet</Menu.Item>
-              <Menu.Item onClick={() => setEnv('sonic-mainnet')}>Sonic Mainnet</Menu.Item>
-              <Menu.Item onClick={() => setEnv('sonic-devnet')}>Sonic Devnet</Menu.Item>
-              <Menu.Item onClick={() => setEnv('localhost')}>Localhost</Menu.Item>
+              {envOptions.map(({ env: e, label }) => (
+                <Menu.Item key={e} onClick={() => setEnv(e)}>{label}</Menu.Item>
+              ))}
             </Menu.Dropdown>
           </Menu>
         </Group>

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import { IconChevronDown } from '@tabler/icons-react';
 import { WalletMultiButton } from '@solana/wallet-adapter-react-ui';
 
 import classes from './Header.module.css';
-import { Env, EnvOption, getEnvOptions } from '@/providers/useEnv';
+import { Env, getEnvOptions } from '@/providers/useEnv';
 import RetainQueryLink from '../RetainQueryLink';
 
 const HeaderLink = ({ label, link, disabled }: { label: string, link: string, disabled?: boolean }) => {

--- a/providers/Providers.tsx
+++ b/providers/Providers.tsx
@@ -11,7 +11,7 @@ import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { Header } from '@/components/Header/Header';
 import { UmiProvider } from './UmiProvider';
 import { EnvProvider } from './EnvProvider';
-import { Env } from './useEnv';
+import { Env, getEnvOptions, getEnvOption } from './useEnv';
 
 export function Providers({ children }: { children: ReactNode }) {
   const router = useRouter();
@@ -19,7 +19,14 @@ export function Providers({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const queryEnv = searchParams.get('env');
   const [client] = useState(new QueryClient());
-  const [env, setEnv] = useState<Env>((queryEnv === 'mainnet' || queryEnv === 'devnet') ? queryEnv : 'mainnet');
+  const envOptions = useMemo(() => getEnvOptions(), []);
+  const [env, setEnv] = useState<Env>(() => {
+    if (queryEnv) {
+      const match = getEnvOption(queryEnv as Env);
+      if (match) return match.env;
+    }
+    return envOptions[0]?.env ?? 'mainnet';
+  });
 
   const doSetEnv = (e: Env) => {
     const params = new URLSearchParams(window.location.search);
@@ -29,32 +36,9 @@ export function Providers({ children }: { children: ReactNode }) {
     router.push(`${pathname}?${params.toString()}`);
   };
 
-  // useEffect(() => {
-  //   if (env === 'devnet' && queryEnv !== 'devnet') {
-  //     doSetEnv('devnet');
-  //   }
-  // }, []);
-
   const endpoint = useMemo(() => {
-    switch (env) {
-      case 'mainnet':
-        return process.env.NEXT_PUBLIC_MAINNET_RPC_URL;
-      case 'eclipse-mainnet':
-        return process.env.NEXT_PUBLIC_ECLIPSE_MAINNET_RPC_URL;
-      case 'sonic-mainnet':
-        return process.env.NEXT_PUBLIC_SONIC_MAINNET_RPC_URL;
-      case 'eclipse-testnet':
-        return process.env.NEXT_PUBLIC_ECLIPSE_TESTNET_RPC_URL;
-      case 'eclipse-devnet':
-        return process.env.NEXT_PUBLIC_ECLIPSE_DEVNET_RPC_URL;
-      case 'sonic-devnet':
-        return process.env.NEXT_PUBLIC_SONIC_DEVNET_RPC_URL;
-      case 'localhost':
-        return 'http://localhost:8899';
-      case 'devnet':
-      default:
-        return process.env.NEXT_PUBLIC_DEVNET_RPC_URL;
-    }
+    const option = getEnvOption(env);
+    return option?.endpoint ?? getEnvOption('mainnet')?.endpoint;
   }, [env]);
 
   return (

--- a/providers/useEnv.ts
+++ b/providers/useEnv.ts
@@ -2,6 +2,33 @@ import { createContext, useContext } from 'react';
 
 export type Env = 'devnet' | 'testnet' | 'mainnet' | 'localhost' | 'eclipse-devnet' | 'eclipse-mainnet' | 'eclipse-testnet' | 'sonic-devnet' | 'sonic-mainnet';
 
+export type EnvOption = {
+  env: Env;
+  label: string;
+  endpoint: string | undefined;
+};
+
+const SOLANA_MAINNET_FALLBACK = 'https://api.mainnet-beta.solana.com';
+
+const allEnvOptions: EnvOption[] = [
+  { env: 'mainnet', label: 'Solana Mainnet', endpoint: process.env.NEXT_PUBLIC_MAINNET_RPC_URL ?? SOLANA_MAINNET_FALLBACK },
+  { env: 'devnet', label: 'Solana Devnet', endpoint: process.env.NEXT_PUBLIC_DEVNET_RPC_URL },
+  { env: 'eclipse-mainnet', label: 'Eclipse Mainnet', endpoint: process.env.NEXT_PUBLIC_ECLIPSE_MAINNET_RPC_URL },
+  { env: 'eclipse-devnet', label: 'Eclipse Devnet', endpoint: process.env.NEXT_PUBLIC_ECLIPSE_DEVNET_RPC_URL },
+  { env: 'eclipse-testnet', label: 'Eclipse Testnet', endpoint: process.env.NEXT_PUBLIC_ECLIPSE_TESTNET_RPC_URL },
+  { env: 'sonic-mainnet', label: 'Sonic Mainnet', endpoint: process.env.NEXT_PUBLIC_SONIC_MAINNET_RPC_URL },
+  { env: 'sonic-devnet', label: 'Sonic Devnet', endpoint: process.env.NEXT_PUBLIC_SONIC_DEVNET_RPC_URL },
+  { env: 'localhost', label: 'Localhost', endpoint: 'http://localhost:8899' },
+];
+
+export function getEnvOptions(): EnvOption[] {
+  return allEnvOptions.filter((o) => o.endpoint);
+}
+
+export function getEnvOption(env: Env): EnvOption | undefined {
+  return getEnvOptions().find((o) => o.env === env);
+}
+
 type EnvContext = {
   env: Env;
 };


### PR DESCRIPTION
- Move env options to a array in useEnv.ts
- Auto-hide networks without configured RPC endpoints
- Validate all env query params, not just mainnet/devnet
- Add Solana mainnet fallback endpoint