### PR TITLE
Add ability to assign assets to collections

### DIFF
--- a/components/Explorer/ManageAssetForm/AddToCollection.tsx
+++ b/components/Explorer/ManageAssetForm/AddToCollection.tsx
@@ -42,7 +42,11 @@ export function AddToCollection({ asset }: AssetWithCollection) {
       invalidate(asset.publicKey);
     } catch (error: any) {
       console.error('Add to collection failed', error);
-      notifications.show({ title: 'Add to collection failed', message: error.message, color: 'red' });
+      notifications.show({ 
+        title: 'Add to collection failed', 
+        message: error?.message || String(error), 
+        color: 'red' 
+      });
     } finally {
       setLoading(false);
     }

--- a/components/Explorer/ManageAssetForm/AddToCollection.tsx
+++ b/components/Explorer/ManageAssetForm/AddToCollection.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useState } from 'react';
+import { useForm } from '@mantine/form';
+import { update, fetchCollectionV1, baseUpdateAuthority } from '@metaplex-foundation/mpl-core';
+import { publicKey } from '@metaplex-foundation/umi';
+import { base58 } from '@metaplex-foundation/umi/serializers';
+import { notifications } from '@mantine/notifications';
+import { Button, Stack, TextInput } from '@mantine/core';
+import { useUmi } from '@/providers/useUmi';
+import { AssetWithCollection } from '@/lib/type';
+import { useInvalidateFetchAssetWithCollection } from '@/hooks/fetch';
+import { validatePubkey } from '@/lib/form';
+
+export function AddToCollection({ asset }: AssetWithCollection) {
+  const umi = useUmi();
+  const [loading, setLoading] = useState(false);
+  const { invalidate } = useInvalidateFetchAssetWithCollection();
+  const form = useForm({
+    initialValues: {
+      collectionAddress: '',
+    },
+    validateInputOnBlur: true,
+    validate: {
+      collectionAddress: (value) => validatePubkey(value) ? null : 'Invalid collection address',
+    },
+  });
+
+  const handleAddToCollection = useCallback(async () => {
+    try {
+      setLoading(true);
+      const collectionPubkey = publicKey(form.values.collectionAddress);
+      const collection = await fetchCollectionV1(umi, collectionPubkey);
+
+      const res = await update(umi, {
+        asset,
+        newCollection: collection.publicKey,
+        newUpdateAuthority: baseUpdateAuthority('Collection', [collection.publicKey]),
+      }).sendAndConfirm(umi);
+
+      const sig = base58.deserialize(res.signature);
+      console.log('Added to collection', sig);
+      notifications.show({ title: 'Added to collection', message: sig, color: 'green' });
+      invalidate(asset.publicKey);
+    } catch (error: any) {
+      console.error('Add to collection failed', error);
+      notifications.show({ title: 'Add to collection failed', message: error.message, color: 'red' });
+    } finally {
+      setLoading(false);
+    }
+  }, [umi, form.values.collectionAddress, asset]);
+
+  return (
+    <Stack gap="xs">
+      <TextInput
+        label="Collection address"
+        placeholder="Enter the collection public key"
+        {...form.getInputProps('collectionAddress')}
+      />
+      <Button onClick={handleAddToCollection} loading={loading} disabled={!form.isValid()}>
+        Add to Collection
+      </Button>
+    </Stack>
+  );
+}

--- a/components/Explorer/ManageAssetForm/AddToCollection.tsx
+++ b/components/Explorer/ManageAssetForm/AddToCollection.tsx
@@ -36,7 +36,7 @@ export function AddToCollection({ asset }: AssetWithCollection) {
         newUpdateAuthority: baseUpdateAuthority('Collection', [collection.publicKey]),
       }).sendAndConfirm(umi);
 
-      const sig = base58.deserialize(res.signature);
+      const [sig] = base58.deserialize(res.signature);
       console.log('Added to collection', sig);
       notifications.show({ title: 'Added to collection', message: sig, color: 'green' });
       invalidate(asset.publicKey);

--- a/components/Explorer/ManageAssetForm/AddToCollection.tsx
+++ b/components/Explorer/ManageAssetForm/AddToCollection.tsx
@@ -46,7 +46,7 @@ export function AddToCollection({ asset }: AssetWithCollection) {
     } finally {
       setLoading(false);
     }
-  }, [umi, form.values.collectionAddress, asset]);
+  }, [umi, form.values.collectionAddress, asset, invalidate]);
 
   return (
     <Stack gap="xs">

--- a/components/Explorer/ManageAssetForm/ManageAssetForm.tsx
+++ b/components/Explorer/ManageAssetForm/ManageAssetForm.tsx
@@ -14,6 +14,7 @@ import { Freeze } from './Freeze';
 import { PermanentFreeze } from './PermanentFreeze';
 import { Attributes } from './Attributes';
 import { Edition } from './Edition';
+import { AddToCollection } from './AddToCollection';
 
 export function ManageAssetForm({ asset, collection }: AssetWithCollection) {
   const umi = useUmi();
@@ -45,6 +46,14 @@ export function ManageAssetForm({ asset, collection }: AssetWithCollection) {
               <Accordion.Item key="update" value="update">
                 <Accordion.Control><Text size="sm">Update asset</Text></Accordion.Control>
                 <Accordion.Panel><Update asset={asset} /></Accordion.Panel>
+              </Accordion.Item>
+            </Accordion>
+          )}
+          {isUpdateAuth && asset.updateAuthority.type === 'Address' && (
+            <Accordion variant="separated">
+              <Accordion.Item key="add-to-collection" value="add-to-collection">
+                <Accordion.Control><Text size="sm">Add to collection</Text></Accordion.Control>
+                <Accordion.Panel><AddToCollection asset={asset} /></Accordion.Panel>
               </Accordion.Item>
             </Accordion>
           )}


### PR DESCRIPTION
## Summary
This PR adds a new feature that allows users to assign digital assets to collections in the asset management interface.

## Key Changes
- **New Component**: Created `AddToCollection.tsx` component that provides a form for users to add an asset to a collection by entering a collection public key
  - Includes validation for the collection address input
  - Handles the transaction submission and confirmation
  - Shows success/error notifications to the user
  - Invalidates the asset cache after successful assignment

- **Updated ManageAssetForm**: Integrated the new `AddToCollection` component into the asset management form
  - Only displays the "Add to collection" section when the user has update authority and the current update authority is an Address type
  - Wrapped in an accordion panel for consistent UI with other management options

## Implementation Details
- Uses Metaplex's `update` function to assign the asset to the collection with appropriate update authority
- Validates public key format before submission
- Displays transaction signature in success notification
- Properly handles loading states and error cases with user-friendly messaging
- Integrates with existing cache invalidation system to refresh asset data after changes

https://claude.ai/code/session_01HCZyDLJzaBKHuAXQLvNfXe